### PR TITLE
Typo in docker name

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ First mandatory step:
 To work with the TestWeave, you need to install a local testnet. To do so, you have to install docker and pull the local testnode image:
 
 ```
-docker pull lucaarweave@arweave-node:0.0.1
+docker pull lucaarweave/arweave-node:0.0.1
 
-docker run -p 1984:1984 lucaarweave@arweave-node:0.0.1
+docker run -p 1984:1984 lucaarweave/arweave-node:0.0.1
 ```
 Thats all. Now you have a fully working arweave node installed on your machine. 
 


### PR DESCRIPTION
It seems like there is a typo in the docker name:
(https://hub.docker.com/layers/lucaarweave/arweave-node/0.0.1/images/sha256-199463b824fcf367834a72567cd1864208dea3527655c3f8196bfa50b1397df8?context=explore)