### PR TITLE
Do not override TestWeave host when making requests

### DIFF
--- a/src/classes/class.testweave-transactions-manager.ts
+++ b/src/classes/class.testweave-transactions-manager.ts
@@ -65,8 +65,6 @@ export default class TestWeaveTransactionsManager implements ITestWeaveTransacti
     try {
       // get the request
       const request = this._arweave.api.request();
-      // console.log(request);
-      request.defaults.baseURL = 'http://localhost';
       const response = await request.get(endpoint, config);
       return response;
     } catch (error) {
@@ -90,9 +88,6 @@ export default class TestWeaveTransactionsManager implements ITestWeaveTransacti
     try {
       // get the request
       const request = this._arweave.api.request();
-      if (endpoint === 'graphql') {
-        request.defaults.baseURL = 'http://localhost';
-      }
       const response = await request.post(endpoint, body, config);
       if (endpoint === 'tx') {
         const { id } = body as Transaction;


### PR DESCRIPTION
The TestWeave SDK works just fine without overriding the API defined host when making requests. Overriding the host prevents users from using the SDK in Docker containers that need to connect to other containers.